### PR TITLE
RFC 74: Core module reorganisation

### DIFF
--- a/text/074-module-reorganisation.md
+++ b/text/074-module-reorganisation.md
@@ -111,7 +111,7 @@ The following modules that are currently in [`wagtail/core/`](https://github.com
 - [`compat.py`](https://github.com/wagtail/wagtail/blob/f2f4503f4ffb1130e770a3dd4d98ef6e47864de3/wagtail/core/compat.py)
 - [`treebeard.py`](https://github.com/wagtail/wagtail/blob/8f8f2e12b731334bbe1e39508a12246a3503f532/wagtail/core/treebeard.py)
 - [`url_routing.py`](https://github.com/wagtail/wagtail/blob/8e25960972a1663b14faca1f7ac6a1693a581b18/wagtail/core/telepath.py)
-- [`whitelist.py`](https://github.com/wagtail/wagtail/blob/ba6f94def17b8bbc66002cbc7af60ed422658ff1/wagtail/core/whitelist.py)
+- [`whitelist.py`](https://github.com/wagtail/wagtail/blob/ba6f94def17b8bbc66002cbc7af60ed422658ff1/wagtail/core/whitelist.py) -> should be renamed to `allowlist` or `safelist` and then `Whitelister` module renamed to `Gatekeeper` or `Safelister`
 
 [`log_actions.py`](https://github.com/wagtail/wagtail/blob/9b28fdba87515bd679806cd1c51ffb04918c15c7/wagtail/core/log_actions.py) will be renamed to `logging.py` as this module contains more than just log actions, but also for consistency with it’s models file (`wagtail/models/logging.py`)
 


### PR DESCRIPTION
This RFC contains a proposal for a reorganisation of Wagtail's core modules. There's a few reasons why we need to do this:

- Improve the navigability of Wagtail's codebase. For example, the code for pages, sites, users, locales is currently scattered across multiple apps
- Make the divide between "core" and "contrib" clearer by putting all modules in contrib
- Shorten imports by removing the `.core` suffix from core modules and `_tags` from template tags

All of these changes will be backwards compatible.

The reorganisation described in this RFC is already been implemented in the [restructure](https://github.com/wagtail/wagtail/tree/restructure) branch. This was developed using a [script](https://github.com/kaedroho/wagtail-restructure-poc/blob/master/restructure.sh) to make the process repeatable on future Wagtail versions.

This branch is available as a `pypi` package: [`wagtail-restructure`](https://pypi.org/project/wagtail-restructure/)

[Rendered](https://github.com/wagtail/rfcs/blob/core-module-reorg/text/074-module-reorganisation.md)