### PR TITLE
RFC 114: Wagtail 8.0 roadmap updates

### DIFF
--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -56,11 +56,16 @@ Overhaul of the `wagtail start` support for custom templates and the news templa
 
 Size: S
 
-We want to improve our processes around vulnerability disclosure and supply chain management, ahead of the EU Cyber Resilience Act. For now the focus will be on improvements that are generally valuable for a wide range cybersecurity requirements, such as:
+Establish what the [EU Cyber Resilience Act](https://digital-strategy.ec.europa.eu/en/policies/cyber-resilience-act) means for Wagtail, as an upstream project in the open source software supply chain, and related security improvements that could be considered. For now the focus will be on improvements that are generally valuable for a wide range cybersecurity requirements, such as:
 
-- Producing SBOMs for our releases, and signing release artifacts
-- Revising our [security policy](https://docs.wagtail.org/en/stable/contributing/security.html), in particular with more information on our behind-the-scenes security team process
+- Revising our [security policies and docs](https://docs.wagtail.org/en/stable/contributing/security.html), in particular with more information on our behind-the-scenes security team process.
+- Producing SBOMs for our releases, and signing release artifacts.
 - Signposting and sharing how to do this as part of the package ecosystem, via changes to our [package guidelines](https://wagtail.org/package-guidelines/).
+
+More info:
+
+- [Security process improvements](https://github.com/wagtail/wagtail/issues/14293)
+- [Self-certification of Wagtail](https://github.com/wagtail/wagtail/issues/14287) under the [OpenSSF Best Practices Badge program](https://openssf.org/projects/best-practices-badge/).
 
 ### [Demo website redesign](https://github.com/wagtail/bakerydemo/issues/566)
 

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -50,7 +50,8 @@ See [RFC 115: write API](https://github.com/wagtail/rfcs/pull/115).
 
 Size: M
 
-Overhaul of the `wagtail start` support for custom templates and the news template for higher usability and maintainability.
+Overhaul of the `wagtail start` support for custom templates and the news template for higher usability and maintainability. Possible `start` command improvements: [start command DX improvements
+ #14350](https://github.com/wagtail/wagtail/issues/14350).
 
 ### Cyber Resilience Act readiness
 

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -3,7 +3,7 @@
 - RFC: 114
 - Author: Thibaud Colas
 - Created: 2026-05-05
-- Last Modified: 2026-05-05
+- Last Modified: 2026-06-09
 
 ## Abstract
 

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -46,14 +46,6 @@ A new official CMS API that supports programmatic creation and modification of W
 
 See [RFC 115: write API](https://github.com/wagtail/rfcs/pull/115).
 
-### [SEO power tools](https://github.com/wagtail/roadmap/issues/106)
-
-Size: M
-
-TBC: which specific improvements we focus on, which we might defer.
-
-See [Looking for sponsorship: SEO power tools](https://wagtail.org/blog/looking-for-sponsorship-seo-power-tools/). New built-in SEO and content quality assurance features, with opportunities for integration with SEO and analytics tools, as well as generative AI.
-
 ### [Starter kit relaunch](https://github.com/wagtail/roadmap/issues/124)
 
 Size: M
@@ -70,40 +62,30 @@ TODO: Explain what the EU Cyber Resilience is and why it matters. For roadmap ne
 - Revising our [security policy](https://docs.wagtail.org/en/stable/contributing/security.html), in particular with more information on our behind-the-scenes security team process
 - Package ecosystem (this ideally should happen for all packages)
 
+### [Demo website redesign](https://github.com/wagtail/bakerydemo/issues/566)
+
+An incremental redesign of the [Wagtail bakery demo site](https://github.com/wagtail/bakerydemo?rgh-link-date=2025-10-23T15%3A14%3A12.000Z), with the intention to make it a more suitable demo for larger projects, and other verticals than breadmaking. This is done as a Google Summer of Code project, started in June 2026.
+
 ## Roadmap for the next+1 release
+
+### [SEO power tools](https://github.com/wagtail/roadmap/issues/106)
+
+Size: M
+
+See [Looking for sponsorship: SEO power tools](https://wagtail.org/blog/looking-for-sponsorship-seo-power-tools/). New built-in SEO and content quality assurance features, with opportunities for integration with SEO and analytics tools, as well as generative AI.
+
+## Roadmap for "Future" releases
 
 ### [Choosers UI improvements](https://github.com/wagtail/roadmap/issues/109)
 
 Size: XL
 
-TBC: Moving back one release :(
-
 Iterative improvements towards a new design for choosers, which brings them closer to the "Universal listings" UX rolled out across listing views.
-
-## Roadmap for "Future" releases
-
-TBC
 
 ## Proposed roadmap items to close
 
-### [Draftail for general text entry](https://github.com/wagtail/roadmap/issues/26)
-
-> Switch to a rich text style UI for plain text inputs, to support more advanced text interactions.
-
-This kind of switch is still desirable but Draftail is likely not the right foundation as the underlying Draft.js library is [unmaintained since 2022](https://github.com/wagtail/draftail/issues/456).
-
-### [Sustainability improvements](https://github.com/wagtail/roadmap/issues/72)
-
-> Improvements across three key areas for Wagtail sites’ carbon footprints: measurements, awareness, tangible reductions.
-
-Most of the improvements tracked in the roadmap item have been happening incrementally, and the remaining ones will be better served by more precise tracking either on the roadmap or directly in our feature backlog.
-
-### [Fully accessible admin](https://github.com/wagtail/roadmap/issues/27)
-
-> Work towards making [Wagtail’s accessibility](https://wagtail.org/accessibility/) world-class – stellar feedback from users of assistive technologies on the admin interface. Full compliance with relevant standards: WCAG, ATAG.
-
-This is the right long-term goal but it’s not served well by being on the roadmap in "Future" with a vague roadmap item. We’re making continuous improvements to the accessibility of Wagtail, so this work is happening anyway.
+None
 
 ## Items that didn't make the cut
 
-TBC
+None

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -1,0 +1,89 @@
+# RFC 114: Public roadmap updates
+
+- RFC: 114
+- Author: Thibaud Colas
+- Created: 2026-05-05
+- Last Modified: 2026-05-05
+
+## Abstract
+
+This RFC provides a high-level overview of proposed [public roadmap](https://github.com/wagtail/roadmap) updates for future releases.
+For context, see [past roadmap-focused RFCs](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+label%3Aroadmap) and the [Wagtail release schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).
+
+## Version number for the next release
+
+Provisional version number: v8.0 (major release), in August 2026 based on discussions to date.
+
+## Roadmap for the previous release
+
+Here is the status of roadmap items for the latest release, v7.4 LTS (May 2026):
+
+| Roadmap item                                                                          | Status | Notes                                     |
+| ------------------------------------------------------------------------------------- | ------ | ----------------------------------------- |
+| [Model search improvements](https://github.com/wagtail/roadmap/issues/116)            | Done   | Shipped as part of django-modelsearch 1.3 |
+| [Customizable page explorer](https://github.com/wagtail/roadmap/issues/102)           | Done   |                                           |
+| [Independent security audit](https://github.com/wagtail/roadmap/issues/111)           | Done   |                                           |
+| [Package maintainers guide](https://github.com/wagtail/roadmap/issues/108)            | Done   |                                           |
+| [Autosave UX enhancements](https://github.com/wagtail/roadmap/issues/127)             | Done   |                                           |
+| [Page editor UX](https://github.com/wagtail/roadmap/issues/123)                       | Done   |                                           |
+| [Content quality checker enhancements](https://github.com/wagtail/roadmap/issues/125) | Done   | Follow-ups in core and packages           |
+
+## Roadmap for the next release
+
+Proposed roadmap items for v8.0 (August 2026).
+
+### [SEO power tools](https://github.com/wagtail/roadmap/issues/106)
+
+Size: M
+
+See [Looking for sponsorship: SEO power tools](https://wagtail.org/blog/looking-for-sponsorship-seo-power-tools/). New built-in SEO and content quality assurance features, with opportunities for integration with SEO and analytics tools, as well as generative AI.
+
+### [Choosers UI improvements](https://github.com/wagtail/roadmap/issues/109)
+
+Size: XL
+
+Iterative improvements towards a new design for choosers, which brings them closer to the "Universal listings" UX rolled out across listing views.
+
+### [Starter kit relaunch](https://github.com/wagtail/roadmap/issues/124)
+
+Size: M
+
+Overhaul of the `wagtail start` support for custom templates and the news template for higher usability and maintainability.
+
+### [Customizable base page model](https://github.com/wagtail/roadmap/issues/126)
+
+Size: M
+
+Introduce an overridable AbstractPage class to allow base page fields to be customized per-project.
+
+## Roadmap for the next+1 release
+
+TBC
+
+## Roadmap for "Future" releases
+
+TBC
+
+## Proposed roadmap items to close
+
+### [Draftail for general text entry](https://github.com/wagtail/roadmap/issues/26)
+
+> Switch to a rich text style UI for plain text inputs, to support more advanced text interactions.
+
+This kind of switch is still desirable but Draftail is likely not the right foundation as the underlying Draft.js library is [unmaintained since 2022](https://github.com/wagtail/draftail/issues/456).
+
+### [Sustainability improvements](https://github.com/wagtail/roadmap/issues/72)
+
+> Improvements across three key areas for Wagtail sites’ carbon footprints: measurements, awareness, tangible reductions.
+
+Most of the improvements tracked in the roadmap item have been happening incrementally, and the remaining ones will be better served by more precise tracking either on the roadmap or directly in our feature backlog.
+
+### [Fully accessible admin](https://github.com/wagtail/roadmap/issues/27)
+
+> Work towards making [Wagtail’s accessibility](https://wagtail.org/accessibility/) world-class – stellar feedback from users of assistive technologies on the admin interface. Full compliance with relevant standards: WCAG, ATAG.
+
+This is the right long-term goal but it’s not served well by being on the roadmap in "Future" with a vague roadmap item. We’re making continuous improvements to the accessibility of Wagtail, so this work is happening anyway.
+
+## Items that didn't make the cut
+
+TBC

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -69,6 +69,8 @@ More info:
 
 ### [Demo website redesign](https://github.com/wagtail/bakerydemo/issues/566)
 
+Size: M
+
 An incremental redesign of the [Wagtail bakery demo site](https://github.com/wagtail/bakerydemo?rgh-link-date=2025-10-23T15%3A14%3A12.000Z), with the intention to make it a more suitable demo for larger projects, and other verticals than breadmaking. This is done as a Google Summer of Code project, started in June 2026.
 
 ## Roadmap for the next+1 release

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -36,13 +36,9 @@ Proposed roadmap items for v8.0 (August 2026).
 
 Size: M
 
+TBC: which specific improvements we focus on, which we might defer.
+
 See [Looking for sponsorship: SEO power tools](https://wagtail.org/blog/looking-for-sponsorship-seo-power-tools/). New built-in SEO and content quality assurance features, with opportunities for integration with SEO and analytics tools, as well as generative AI.
-
-### [Choosers UI improvements](https://github.com/wagtail/roadmap/issues/109)
-
-Size: XL
-
-Iterative improvements towards a new design for choosers, which brings them closer to the "Universal listings" UX rolled out across listing views.
 
 ### [Starter kit relaunch](https://github.com/wagtail/roadmap/issues/124)
 
@@ -56,9 +52,29 @@ Size: M
 
 Introduce an overridable AbstractPage class to allow base page fields to be customized per-project.
 
+### Cyber Resilience Act readiness
+
+TODO: Explain what the EU Cyber Resilience is and why it matters. For roadmap next release: focus on supply chain management
+
+- SBOM & release signing
+- Revising our [security policy](https://docs.wagtail.org/en/stable/contributing/security.html), in particular with more information on our behind-the-scenes security team process
+- Package ecosystem (this ideally should happen for all packages)
+
+### Write API
+
+A new official CMS API that supports programmatic creation and modification of Wagtail-managed content, including pages, snippets, revisions, and editorial workflow state transitions. The goal is to support integrations, automation, structured content workflows, and AI-assisted tooling while preserving Wagtail’s editorial governance, permissions, accessibility, and auditability guarantees.
+
+See [RFC 115: write API](https://github.com/wagtail/rfcs/pull/115).
+
 ## Roadmap for the next+1 release
 
-TBC
+### [Choosers UI improvements](https://github.com/wagtail/roadmap/issues/109)
+
+Size: XL
+
+TBC: Moving back one release :(
+
+Iterative improvements towards a new design for choosers, which brings them closer to the "Universal listings" UX rolled out across listing views.
 
 ## Roadmap for "Future" releases
 

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -56,11 +56,11 @@ Overhaul of the `wagtail start` support for custom templates and the news templa
 
 Size: S
 
-TODO: Explain what the EU Cyber Resilience is and why it matters. For roadmap next release: focus on supply chain management
+We want to improve our processes around vulnerability disclosure and supply chain management, ahead of the EU Cyber Resilience Act. For now the focus will be on improvements that are generally valuable for a wide range cybersecurity requirements, such as:
 
-- SBOM & release signing
+- Producing SBOMs for our releases, and signing release artifacts
 - Revising our [security policy](https://docs.wagtail.org/en/stable/contributing/security.html), in particular with more information on our behind-the-scenes security team process
-- Package ecosystem (this ideally should happen for all packages)
+- Signposting and sharing how to do this as part of the package ecosystem, via changes to our [package guidelines](https://wagtail.org/package-guidelines/).
 
 ### [Demo website redesign](https://github.com/wagtail/bakerydemo/issues/566)
 

--- a/text/114-roadmap-updates.md
+++ b/text/114-roadmap-updates.md
@@ -32,6 +32,20 @@ Here is the status of roadmap items for the latest release, v7.4 LTS (May 2026):
 
 Proposed roadmap items for v8.0 (August 2026).
 
+### [Customizable base page model](https://github.com/wagtail/roadmap/issues/126)
+
+Size: XL
+
+Introduce an overridable AbstractPage class to allow base page fields to be customized per-project.
+
+### Write API
+
+Size: XL
+
+A new official CMS API that supports programmatic creation and modification of Wagtail-managed content, including pages, snippets, revisions, and editorial workflow state transitions. The goal is to support integrations, automation, structured content workflows, and AI-assisted tooling while preserving Wagtail’s editorial governance, permissions, accessibility, and auditability guarantees.
+
+See [RFC 115: write API](https://github.com/wagtail/rfcs/pull/115).
+
 ### [SEO power tools](https://github.com/wagtail/roadmap/issues/106)
 
 Size: M
@@ -46,25 +60,15 @@ Size: M
 
 Overhaul of the `wagtail start` support for custom templates and the news template for higher usability and maintainability.
 
-### [Customizable base page model](https://github.com/wagtail/roadmap/issues/126)
-
-Size: M
-
-Introduce an overridable AbstractPage class to allow base page fields to be customized per-project.
-
 ### Cyber Resilience Act readiness
+
+Size: S
 
 TODO: Explain what the EU Cyber Resilience is and why it matters. For roadmap next release: focus on supply chain management
 
 - SBOM & release signing
 - Revising our [security policy](https://docs.wagtail.org/en/stable/contributing/security.html), in particular with more information on our behind-the-scenes security team process
 - Package ecosystem (this ideally should happen for all packages)
-
-### Write API
-
-A new official CMS API that supports programmatic creation and modification of Wagtail-managed content, including pages, snippets, revisions, and editorial workflow state transitions. The goal is to support integrations, automation, structured content workflows, and AI-assisted tooling while preserving Wagtail’s editorial governance, permissions, accessibility, and auditability guarantees.
-
-See [RFC 115: write API](https://github.com/wagtail/rfcs/pull/115).
 
 ## Roadmap for the next+1 release
 


### PR DESCRIPTION
[Wagtail 7.4 is out](https://wagtail.org/blog/wagtail-74/)! Come review the new features with us at the [What’s New in Wagtail webinar](https://wagtail.org/blog/whats-new-in-wagtail-may-2026/) in a couple of weeks!

[View the RFC in HTML](https://github.com/thibaudcolas/rfcs/blob/114-roadmap/text/114-roadmap-updates.md). Once reviewed with enough feedback and approved by the core team, those changes will go live on the [Wagtail Roadmap](https://wagtail.org/roadmap/).